### PR TITLE
Add location store (read-only)

### DIFF
--- a/server/db/migrations.sql
+++ b/server/db/migrations.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS colleges (
 
 CREATE TABLE IF NOT EXISTS locations (
     "id" VARCHAR PRIMARY KEY,
-    "collegeId" VARCHAR PRIMARY KEY,
+    "collegeId" VARCHAR NOT NULL,
     "locationType" INTEGER NOT NULL,
     "name" VARCHAR(255) NOT NULL,
-    "rating" FLOAT NOT NULL,
+    "rating" FLOAT NOT NULL
 );

--- a/server/db/migrations.sql
+++ b/server/db/migrations.sql
@@ -4,3 +4,11 @@ CREATE TABLE IF NOT EXISTS colleges (
     "rating" FLOAT NOT NULL,
     "photo" VARCHAR NULL
 );
+
+CREATE TABLE IF NOT EXISTS locations (
+    "id" VARCHAR PRIMARY KEY,
+    "collegeId" VARCHAR PRIMARY KEY,
+    "locationType" INTEGER NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "rating" FLOAT NOT NULL,
+);

--- a/server/db/postgres/college.ts
+++ b/server/db/postgres/college.ts
@@ -34,8 +34,8 @@ export class CollegeStorePg implements CollegeStore {
     } 
 
     getAllColleges = async (): Promise<College[]> =>  {
-        const entities = await this.repo.find(); 
-        return entities.map(entity => entity.toObj()); 
+        const colleges = await this.repo.find(); 
+        return colleges.map(college => college.toObj()); 
     }
 
     getCollege = async (id: string): Promise<College | null> => {

--- a/server/db/postgres/location.ts
+++ b/server/db/postgres/location.ts
@@ -1,0 +1,49 @@
+import { Repository, DataSource, Entity, Column, PrimaryColumn } from "typeorm"
+import { Location, LocationType } from "../schema"; 
+import { LocationStore } from "../store";
+
+@Entity("locations")
+export class LocationModel {
+    @PrimaryColumn()
+    id: string
+
+    @Column()
+    collegeId: string
+
+    @Column()
+    locationType: LocationType
+
+    @Column()
+    name: string
+
+    @Column()
+    rating: number
+
+    toObj = (): Location => {
+        return {
+            id: this.id,
+            collegeId: this.collegeId,
+            locationType: this.locationType,
+            name: this.name,
+            rating: this.rating
+        }
+    }
+}
+
+export class LocationStorePg implements LocationStore {
+    repo: Repository<LocationModel>; 
+
+    constructor(conn: DataSource) {
+        this.repo = conn.getRepository(LocationModel); 
+    } 
+
+    getLocation = async (id: string): Promise<Location | null> => {
+        const location = await this.repo.findOneBy({ id: id }); 
+        return location ? location.toObj() : null; 
+    }
+
+    getLocationsByCollege = async (collegeId: string): Promise<Location[]> => {
+        const locations = await this.repo.findBy({ collegeId: collegeId }); 
+        return locations.map(location => location.toObj()); 
+    }
+}

--- a/server/db/store.ts
+++ b/server/db/store.ts
@@ -1,6 +1,11 @@
-import { College } from "./schema"; 
+import { College, Location } from "./schema"; 
 
 export interface CollegeStore {
     getAllColleges(): Promise<College[]>; 
     getCollege(id: string): Promise<College | null>; 
+}
+
+export interface LocationStore {
+    getLocation(id: string): Promise<Location | null>; 
+    getLocationsByCollege(collegeId: string): Promise<Location[]>;  
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,8 +1,9 @@
 import { DataSource } from "typeorm"
-import { CollegeModel, CollegeStorePg } from "./db/postgres/college" 
 import { getConfig } from "./config"; 
 import { ExpressServer } from "./api/express";
 import { CollegeResourceImpl } from "./api/resources/college";
+import { CollegeModel, CollegeStorePg } from "./db/postgres/college"
+import { LocationModel, LocationStorePg } from "./db/postgres/location"  
 
 const main = async () => {
     const config = getConfig(); 
@@ -17,14 +18,15 @@ const main = async () => {
             password: config.postgresConfig.password,
             port: config.postgresConfig.port,
             database: config.postgresConfig.database,
-            entities: [CollegeModel],
+            entities: [CollegeModel, LocationModel],
         })    
     
         await conn.initialize(); 
     
         // db stores
         const collegeStore = new CollegeStorePg(conn); 
-
+        const locationStore = new LocationStorePg(conn); 
+        
         // resources
         const collegeResource = new CollegeResourceImpl(collegeStore); 
 


### PR DESCRIPTION
This PR adds a location store for interacting with the `Location` tbl. For now, it only has read-only methods (getting by id, getting by college), in a later PR, the methods for updating and creating a location will be added.

addresses: #8 