### PR TITLE
Add `photo` column to `locations` table

### DIFF
--- a/server/db/migrations.sql
+++ b/server/db/migrations.sql
@@ -36,3 +36,5 @@ CREATE TABLE IF NOT EXISTS reviews (
     "rating" FLOAT NOT NULL,
     "comment" VARCHAR NULL
 );
+
+ALTER TABLE locations ADD COLUMN IF NOT EXISTS photo VARCHAR NULL;

--- a/server/db/postgres/location.ts
+++ b/server/db/postgres/location.ts
@@ -31,6 +31,9 @@ export class LocationModel {
     @Column()
     longitude: number; 
 
+    @Column()
+    photo?: string
+
     toObj = (): Location => {
         return {
             id: this.id,
@@ -42,6 +45,7 @@ export class LocationModel {
             address: this.address,
             latitude: this.latitude,
             longitude: this.longitude, 
+            photo: this.photo,
         }
     }
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -45,4 +45,5 @@ export type Location = {
     address: string; 
     latitude: number; 
     longitude: number; 
+    photo?: string; 
 }


### PR DESCRIPTION
This PR adds a `photo` column to the `locations` table. The photo is an optional string which represents the reference to the location image.

addresses: #8 